### PR TITLE
Update README with node as a prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ CoopERP is an eco-design and open-source ERP solution for cooperatives.
 
 ## Prerequisites
 
-You must have [Docker](https://www.docker.com/) and [Docker Compose](https://docs.docker.com/compose/) installed on your system.
+You must have [Docker](https://www.docker.com/) and [Docker Compose](https://docs.docker.com/compose/) installed on your system. You also need Node in version at least 10 installed on your system.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ CoopERP is an eco-design and open-source ERP solution for cooperatives.
 
 ## Prerequisites
 
-You must have [Docker](https://www.docker.com/) and [Docker Compose](https://docs.docker.com/compose/) installed on your system. You also need Node in version at least 10 installed on your system.
+You must have [Docker](https://www.docker.com/) and [Docker Compose](https://docs.docker.com/compose/) installed on your system. You also need [Node](https://nodejs.org/en/) in version at least 12 installed on your system.
 
 ## Installation
 


### PR DESCRIPTION
I installed the project on my mac and had errors : 

The `make install` command run `npm install` directly on the machine instead of inside the node container, therefore, you'll need Node installed. I had an old version of node (9) installed and the install process had a few errors.

With an upgrade to node 13 (current), no problem during the install.

Should we change the install to be run inside the container to avoid dealing with current version install on the machine ?
